### PR TITLE
fix: update maven mirror to Apache's new CDN

### DIFF
--- a/tools/maven-3/install.sh
+++ b/tools/maven-3/install.sh
@@ -8,7 +8,7 @@ set -eux
 # See check-updates.sh.
 MAVEN_VERSION=3.6.3
 SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
-BASE_URL=https://mirror.netcologne.de/apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
+BASE_URL=https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
 
 mkdir -p /usr/share/maven /usr/share/maven/ref
 wget -O /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz


### PR DESCRIPTION
Our previous mirror has stopped working as
Apache recently deprecated the mirror system they previously used,
and is now recommending using their new CDN.

See article for more details:
https://web.archive.org/web/20211101114833/https://blogs.apache.org/foundation/entry/apache-software-foundation-moves-to