### PR TITLE
fix: update url for maven binaries

### DIFF
--- a/tools/maven-3/install.sh
+++ b/tools/maven-3/install.sh
@@ -8,7 +8,9 @@ set -eux
 # See check-updates.sh.
 MAVEN_VERSION=3.6.3
 SHA=c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
-BASE_URL=https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries
+# NOTE: We previously used https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries as the URL,
+# but only the two latest minor versions are available there
+BASE_URL=https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries
 
 mkdir -p /usr/share/maven /usr/share/maven/ref
 wget -O /tmp/apache-maven.tar.gz ${BASE_URL}/apache-maven-${MAVEN_VERSION}-bin.tar.gz


### PR DESCRIPTION
The previous URL is giving us a 404 when trying to download the binary because only the newest versions are stored there. We may want to revert back to the previous URL if we add automatic updates of the Maven binary (which is now pinned to v3.6.3).